### PR TITLE
Use nix file to set nixpkgs version

### DIFF
--- a/manage
+++ b/manage
@@ -49,7 +49,7 @@ command -v nix-shell >/dev/null 2>&1 || {
   fi
 }
 
-here=$(dirname "$0")
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "$here" && git rev-parse --show-toplevel)  # Use Git to find repo root.
 
 deployment="$1"

--- a/nixpkgs-version.nix
+++ b/nixpkgs-version.nix
@@ -1,0 +1,14 @@
+# Check out different Nixpkgs channels here:
+#   * http://howoldis.herokuapp.com/
+#   * https://nixos.org/channels/
+#
+# To upgrade:
+#   1. Choose a channel and click on it.
+#   2. Get the URL of the `nixexprs.tar.xz` file for the channel.
+#   4. Paste the URL below for `url`.
+#   5. Get SHA256 hash of URL contents with `nix-prefetch-url --unpack <url>`.
+
+{
+  url    = "https://d3g5gsiof5omrk.cloudfront.net/nixpkgs/nixpkgs-17.03pre101896.4a524cf/nixexprs.tar.xz";
+  sha256 = "1wrm9k0plpzz0wi94ry1xv1v3aq4vs20v5dzxv4azn4i8vhf7wmg";
+}

--- a/nixpkgs-version.sh
+++ b/nixpkgs-version.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-export nixpkgs_channel="https://nixos.org/channels/nixpkgs-unstable"
-export nixpkgs_snapshot="https://d3g5gsiof5omrk.cloudfront.net/nixpkgs/nixpkgs-17.03pre98765.6043569/nixexprs.tar.xz"
-export nixops_version="nixops"  # Use the packaged nixops
+
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+nixpkgs_snapshot=$(eval echo "$(nix-instantiate --eval -E "(import \"$here/nixpkgs-version.nix\").url")")
+export nixpkgs_snapshot
+export nixops_version="nixops"
 
 # Or you can use a more recent build of nixops:
 #if [ "$(uname)" == "Darwin" ]; then

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,3 @@
+# Import this instead of <nixpkgs> to get the repo-specific version of nixpkgs.
+
+import ((import <nixpkgs> {}).fetchzip (import ./nixpkgs-version.nix))


### PR DESCRIPTION
This makes it easier to other nix derivations in the repo to use the same snapshot that's being used for deployments.

Fixes #1